### PR TITLE
Call Super::Tick in TPSCharacter

### DIFF
--- a/Game/Source/ThirdPersonShooter/Characters/TPSCharacter.cpp
+++ b/Game/Source/ThirdPersonShooter/Characters/TPSCharacter.cpp
@@ -102,6 +102,8 @@ void ATPSCharacter::Tick(float DeltaSeconds)
 	{
 		UpdateAimRotation(LocalAimUpdateThreshold);
 	}
+
+	Super::Tick(DeltaSeconds);
 }
 
 void ATPSCharacter::UpdateTeamColor()


### PR DESCRIPTION
Blueprint Tick event won't be called unless you call `Super::Tick`.