### PR TITLE
Work-around for run-2737 issue

### DIFF
--- a/spatial/default_launch.json
+++ b/spatial/default_launch.json
@@ -17,6 +17,10 @@
           "value": "0"
         },
         {
+          "name": "bridge_soft_handover_enabled",
+          "value": "false"
+        },
+        {
           "name": "qos_max_unacked_pings_rate",
           "value": "10"
         }


### PR DESCRIPTION
**Description**
Updating default_launch.json to disable soft handover that were occurring while testing UnrealGDKShooterGame.

the jira ticket run-2737 seems to be due to soft handover issues. So disabling it in the project to halt the add/remove entity ops that come in the same frame.

**Tests**
Tested originally on UnrealGDKShooterGame for https://github.com/improbable/UnrealGDKShooterGame/pull/3 

**Primary reviewers**
@girayimprobable @joshuahuburn