### PR TITLE
Fix scoreboard for multiworker

### DIFF
--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
@@ -12,7 +12,7 @@ ATPSGameState::ATPSGameState()
 	PrimaryActorTick.bCanEverTick = false;
 }
 
-void ATPSGameState::AddPlayer(ETPSTeam Team, const FString& Player)
+void ATPSGameState::AddPlayer_Implementation(ETPSTeam Team, const FString& Player)
 {
 	if (Team == ETPSTeam::Team_None || Team > ETPSTeam::Team_MAX)
 	{
@@ -26,7 +26,7 @@ void ATPSGameState::AddPlayer(ETPSTeam Team, const FString& Player)
 	}
 }
 
-void ATPSGameState::AddDeath(const FString& KillerName, ETPSTeam KillerTeam, const FString& VictimName, ETPSTeam VictimTeam)
+void ATPSGameState::AddDeath_Implementation(const FString& KillerName, ETPSTeam KillerTeam, const FString& VictimName, ETPSTeam VictimTeam)
 {
 	// Ignore invalid teams.
 	if (VictimTeam >= ETPSTeam::Team_MIN && VictimTeam <= ETPSTeam::Team_MAX)

--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.h
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.h
@@ -21,9 +21,11 @@ public:
 	ATPSGameState();
 
 	// Adds a player to the game's score data with empty stats.
+	UFUNCTION(CrossServer, Reliable)
 	void AddPlayer(ETPSTeam Team, const FString& Player);
 
 	// Adds a death (and a corresponding kill, if necessary) to the game's score data.
+	UFUNCTION(CrossServer, Reliable)
 	void AddDeath(const FString& KillerName, ETPSTeam KillerTeam, const FString& VictimName, ETPSTeam VictimTeam);
 
 	// [client] Registers a listener for changes in the scoreboard.


### PR DESCRIPTION
When running with multiple servers and if the GameState is on a different worker than the one spawning the players, the scoreboard is not populated on the authoritative GameState when players join or score a kill.