### PR TITLE
Allow clients to forward `stat` commands to all other workers

### DIFF
--- a/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.cpp
+++ b/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.cpp
@@ -418,6 +418,24 @@ void ATPSPlayerController::DeleteCharacter()
 	}
 }
 
+void ATPSPlayerController::BroadcastStat(const FString& StatCommand)
+{
+	BroadcastStat_ServerWorker(StatCommand);
+}
+
+bool ATPSPlayerController::BroadcastStat_ServerWorker_Validate(const FString& StatCommand)
+{
+	return true;
+}
+
+void ATPSPlayerController::BroadcastStat_ServerWorker_Implementation(const FString& StatCommand)
+{
+	if (ATPSGameState* GS = Cast<ATPSGameState>(GetWorld()->GetGameState()))
+	{
+		GS->BroadcastStat_CrossServer(StatCommand);
+	}
+}
+
 void ATPSPlayerController::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);

--- a/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.cpp
+++ b/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.cpp
@@ -430,9 +430,14 @@ bool ATPSPlayerController::BroadcastStat_ServerWorker_Validate(const FString& St
 
 void ATPSPlayerController::BroadcastStat_ServerWorker_Implementation(const FString& StatCommand)
 {
-	if (ATPSGameState* GS = Cast<ATPSGameState>(GetWorld()->GetGameState()))
+	UWorld* World = GetWorld();
+	if(World != nullptr)
 	{
-		GS->BroadcastStat_CrossServer(StatCommand);
+		ATPSGameState* GS = Cast<ATPSGameState>(World->GetGameState());
+		if (GS != nullptr)
+		{
+			GS->BroadcastStat_CrossServer(StatCommand);
+		}
 	}
 }
 

--- a/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.h
+++ b/Game/Source/ThirdPersonShooter/Characters/TPSPlayerController.h
@@ -128,6 +128,12 @@ private:
 	FTimerHandle RespawnTimerHandle;
 	FTimerHandle DeleteCharacterTimerHandle;
 
+	UFUNCTION(Exec)
+	void BroadcastStat(const FString& StatCommand);
+
+	UFUNCTION(Server, Reliable, WithValidation)
+	void BroadcastStat_ServerWorker(const FString& StatCommand);
+
 // HACK for login state (Unreal issue, not GDK issue)
 //=================================================//
 public:

--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
@@ -5,8 +5,6 @@
 #include "TPSLogging.h"
 #include "Teams/TPSTeams.h"
 #include "UnrealNetwork.h"
-#include "Engine/Engine.h"
-
 
 ATPSGameState::ATPSGameState()
 {
@@ -109,46 +107,33 @@ void ATPSGameState::BroadcastStat_CrossServer_Implementation(const FString& Stat
 
 void ATPSGameState::BroadcastStat_Implementation(const FString& StatCommand)
 {
-	FString netMode;
+	FString NetModeString;
 
 	switch (GetNetMode())
 	{
 	case NM_Standalone:
-		netMode = "NM_Standalone";
+		NetModeString = "NM_Standalone";
 		break;
 	case NM_Client:
-		netMode = "NM_Client";
+		NetModeString = "NM_Client";
 		break;
 	case NM_DedicatedServer:
-		netMode = "NM_DedicatedServer";
+		NetModeString = "NM_DedicatedServer";
 		break;
 	case NM_ListenServer:
-		netMode = "NM_ListenServer";
+		NetModeString = "NM_ListenServer";
 		break;
 	default:;
 	}
 
-	FString role;
+	const UEnum* NetRoleType = FindObjectChecked<UEnum>(ANY_PACKAGE, TEXT("ENetRole"));
 
-	switch (Role)
-	{
-	case ROLE_Authority:
-		role = "ROLE_Authority";
-		break;
-	case ROLE_AutonomousProxy:
-		role = "ROLE_AutonomousProxy";
-		break;
-	case ROLE_SimulatedProxy:
-		role = "ROLE_SimulatedProxy";
-		break;
-	default:;
-	}
+	UE_LOG(LogTPS, Log, TEXT("Executing \"STAT %s\", NetMode: %s, Role: %s"), 
+		*StatCommand, 
+		*NetModeString,
+		*NetRoleType->GetNameByValue((int64)Role).ToString());
 
-	UE_LOG(LogTPS, Warning, TEXT("Executing \"STAT %s\", Netmode: %s, Role: %s"), *StatCommand, *netMode, *role);
-
-	FString const fullCommand = TEXT("STAT ") + StatCommand;
-
-	GEngine->Exec(nullptr, *fullCommand, *GLog);
+	GEngine->Exec(nullptr, *FString::Printf(TEXT("STAT %s"), *StatCommand), *GLog);
 }
 
 void ATPSGameState::OnRep_TeamScores()

--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
@@ -6,6 +6,7 @@
 #include "Teams/TPSTeams.h"
 #include "UnrealNetwork.h"
 
+
 ATPSGameState::ATPSGameState()
 {
 	PrimaryActorTick.bCanEverTick = false;

--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.cpp
@@ -5,6 +5,7 @@
 #include "TPSLogging.h"
 #include "Teams/TPSTeams.h"
 #include "UnrealNetwork.h"
+#include "Engine/Engine.h"
 
 
 ATPSGameState::ATPSGameState()
@@ -99,6 +100,55 @@ void ATPSGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME(ATPSGameState, TeamScores);
+}
+
+void ATPSGameState::BroadcastStat_CrossServer_Implementation(const FString& StatCommand)
+{
+	BroadcastStat(StatCommand);
+}
+
+void ATPSGameState::BroadcastStat_Implementation(const FString& StatCommand)
+{
+	FString netMode;
+
+	switch (GetNetMode())
+	{
+	case NM_Standalone:
+		netMode = "NM_Standalone";
+		break;
+	case NM_Client:
+		netMode = "NM_Client";
+		break;
+	case NM_DedicatedServer:
+		netMode = "NM_DedicatedServer";
+		break;
+	case NM_ListenServer:
+		netMode = "NM_ListenServer";
+		break;
+	default:;
+	}
+
+	FString role;
+
+	switch (Role)
+	{
+	case ROLE_Authority:
+		role = "ROLE_Authority";
+		break;
+	case ROLE_AutonomousProxy:
+		role = "ROLE_AutonomousProxy";
+		break;
+	case ROLE_SimulatedProxy:
+		role = "ROLE_SimulatedProxy";
+		break;
+	default:;
+	}
+
+	UE_LOG(LogTPS, Warning, TEXT("Executing \"STAT %s\", Netmode: %s, Role: %s"), *StatCommand, *netMode, *role);
+
+	FString const fullCommand = TEXT("STAT ") + StatCommand;
+
+	GEngine->Exec(nullptr, *fullCommand, *GLog);
 }
 
 void ATPSGameState::OnRep_TeamScores()

--- a/Game/Source/ThirdPersonShooter/Game/TPSGameState.h
+++ b/Game/Source/ThirdPersonShooter/Game/TPSGameState.h
@@ -29,12 +29,17 @@ public:
 	// [client] Registers a listener for changes in the scoreboard.
 	void RegisterScoreChangeListener(FSGTeamScoresUpdatedDelegate Callback);
 
+	UFUNCTION(CrossServer, Reliable)
+	void BroadcastStat_CrossServer(const FString& StatCommand);
 protected:
 	virtual void BeginPlay() override;
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
 private:
+	UFUNCTION(NetMulticast, Reliable)
+	void BroadcastStat(const FString& StatCommand);
+
 	UFUNCTION()
 	void OnRep_TeamScores();
 


### PR DESCRIPTION
Usage:

From clients, in the console,

Instead of:
```
STAT ...
```

If you do:
```
BroadcastStat ...
```

It should execute the `stat ...` command on all workers