### PR TITLE
0.5.0-preview Opt-in Release

### DIFF
--- a/spatial/spatialos.json
+++ b/spatial/spatialos.json
@@ -1,11 +1,11 @@
 {
   "name": "unreal_gdk_third_person_shooter",
   "project_version": "0.0.1",
-  "sdk_version": "13.5.0",
+  "sdk_version": "13.7.1",
   "dependencies": [
     {
       "name": "standard_library",
-      "version": "13.5.0"
+      "version": "13.7.1"
     }
   ]
 }


### PR DESCRIPTION
This is our first opt-in (preview) release of the Unreal GDK Third Person Shooter, which is aimed at teams already developing on the GDK and working closely with Improbable. We do not recommend upgrading to this version unless you have production support from Improbable.
We are preparing a public release including these changes in the near future.